### PR TITLE
[LOG-69] 🚑 hotfix: fixed eslint-ignore /children,reactHook

### DIFF
--- a/pages/post/[pid]/Detail.tsx
+++ b/pages/post/[pid]/Detail.tsx
@@ -8,6 +8,9 @@ import rehypeRaw from 'rehype-raw';
 import remarkGfm from 'remark-gfm';
 
 const Detail = () => {
+  const {
+    query: { pid },
+  } = useRouter();
   const { data: mockData, isLoading } = useQuery('detail', async () => {
     const res = await axios(
       'https://raw.githubusercontent.com/mxstbr/markdown-test-file/master/TEST.md'
@@ -16,10 +19,6 @@ const Detail = () => {
   });
 
   if (isLoading) return <h1>Loading...</h1>;
-  const {
-    query: { pid },
-    // eslint-disable-next-line
-  } = useRouter();
 
   return (
     <main>
@@ -27,8 +26,6 @@ const Detail = () => {
         I&apos;m Detail Page {pid}
       </h1>
       <ReactMarkdown
-        // eslint-disable-next-line
-        children={mockData?.data}
         className="contentMarkdown"
         rehypePlugins={[rehypeRaw]}
         remarkPlugins={[remarkGfm]}
@@ -58,7 +55,9 @@ const Detail = () => {
             );
           },
         }}
-      ></ReactMarkdown>
+      >
+        {mockData?.data}
+      </ReactMarkdown>
     </main>
   );
 };


### PR DESCRIPTION
## 연관 이슈

[LOG-69](https://cvlog.atlassian.net/browse/LOG-69)

## 풀리퀘스트 유형

<!-- [x] 로 체크 -->

- [ ] 버그수정
- [ ] 기능추가
- [ ] 기능개선
- [ ] 기능삭제
- [x] 리팩토링
- [ ] 기타 (우측에 설명기입): 

## 구현 사항

eslint-ignore 수정
## 특이사항

-

## 구현 화면

-


[LOG-69]: https://cvlog.atlassian.net/browse/LOG-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ